### PR TITLE
Fix the TS error caused by the errant semicolon after an interface declaration.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface Logger {
     debug: (...args: unknown[]) => void;
     log: (...args: unknown[]) => void;
     getName: () => string;
-};
+}
 
 /**
  * Get a new Logger instance with the given name and optional parent logger.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akshat1/js-logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple JS logger.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix the TS error caused by the errant semicolon after an interface declaration.

- Version bump for the bugfix.
- Version 1.0.2

```
node_modules/@akshat1/js-logger/index.d.ts:11:2 - error TS1036: Statements are not allowed in ambient contexts.
```