### PR TITLE
Better error logging - now includes any extra properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kabukisolutions/js-logger",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": "Simple JS logger.",
   "main": "lib/index.js",
   "type": "module",

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -8,14 +8,26 @@
  */
 export type Transformer = (message: unknown, next?: Transformer) => unknown;
 
+/**
+ * Transform incoming Error objects into plain objects that contain all the properties of the Error object, including
+ * the non-enumerable ones. All other types pass through unchanged.
+ *
+ * @param message - The message to transform. This may or may not be an Error object.
+ * @param next - The next transformer in the chain. Optional.
+ * @returns The transformed message.
+ */
 const transformAnError: Transformer = (message: unknown, next?: Transformer) => {
   if (message instanceof Error) {
-    return {
-      name   : message.name,
-      message: message.message,
-      stack  : message.stack,
+    const errLike = message as Record<string, unknown> & Partial<Pick<Error, "stack" | "name" | "message">>;
+    const transformed = {
+      ...errLike,
+      stack  : errLike.stack,
+      name   : errLike.name,
+      message: errLike.message,
     };
+    return next ? next(transformed) : transformed;
   }
+
   return next ? next(message) : message;
 };
 


### PR DESCRIPTION
Better error logging - now includes any extra properties in addition to name, stack, and message.

This does change the error logging behavior - previously, only the stack, name, and message would be logged. That effectively redacted all "extra" properties (if present) on the error object.. If anyone was (perhaps unknowingly) reliant on the old behavior, they could potentially start leaking information into the logs. Therefore, this is a major version bump.